### PR TITLE
Draw the live standings green line at the configured knockout size

### DIFF
--- a/src/pages/DisplayPage.tsx
+++ b/src/pages/DisplayPage.tsx
@@ -154,6 +154,7 @@ export default function DisplayPage() {
           knockoutResults={knockoutResults}
           champion={champion}
           totalRounds={tournament?.total_rounds ?? 7}
+          playoffSize={playoffSize}
           status={status}
           currentRound={currentRound}
           large

--- a/src/pages/admin/components/StandingsTable.tsx
+++ b/src/pages/admin/components/StandingsTable.tsx
@@ -4,13 +4,14 @@ import type { TeamStanding } from '@/lib/tournament-engine';
 
 interface Props {
   standings: TeamStanding[];
-  highlightTop?: number;
+  /** Teams advancing into the knockout — drives the playoff highlight. Pass the configured size, not a literal. */
+  highlightTop: number;
   compact?: boolean;
 }
 
 export default function StandingsTable({
   standings,
-  highlightTop = 8,
+  highlightTop,
   compact = false,
 }: Props) {
   if (standings.length === 0) return null;

--- a/src/pages/admin/components/TournamentMapView.tsx
+++ b/src/pages/admin/components/TournamentMapView.tsx
@@ -18,6 +18,8 @@ interface TournamentMapViewProps {
   knockoutResults: MatchResult[];
   champion: string | null;
   totalRounds: number;
+  /** Teams advancing from Swiss into the knockout — drives the standings cutoff highlight. */
+  playoffSize: number;
   status: string;
   onEditMatch?: (matchId: string) => void;
   large?: boolean;
@@ -298,6 +300,7 @@ export default function TournamentMapView({
   knockoutResults,
   champion,
   totalRounds,
+  playoffSize,
   status,
   onEditMatch,
   large,
@@ -357,7 +360,7 @@ export default function TournamentMapView({
                 </div>
               </div>
             )}
-            <StandingsColumn standings={standings} highlightTop={8} large={large} />
+            <StandingsColumn standings={standings} highlightTop={playoffSize} large={large} />
           </div>
         </div>
       )}

--- a/src/pages/admin/tabs/SimulatorTab.tsx
+++ b/src/pages/admin/tabs/SimulatorTab.tsx
@@ -728,6 +728,7 @@ function MapView({ state }: { state: SimState }) {
       knockoutResults={state.knockoutResults}
       champion={state.champion}
       totalRounds={state.config.swissRounds}
+      playoffSize={state.config.knockoutSize}
       status={mapStatus}
     />
   );

--- a/src/pages/admin/tabs/TournamentTab.tsx
+++ b/src/pages/admin/tabs/TournamentTab.tsx
@@ -723,6 +723,7 @@ export default function TournamentTab({ onTabChange }: TournamentTabProps) {
             knockoutResults={knockoutResults}
             champion={champion}
             totalRounds={tournament?.total_rounds ?? 7}
+            playoffSize={playoffSize}
             status={status}
             onEditMatch={setEditingMatchId}
           />


### PR DESCRIPTION
## Problem

The variable knockout-size feature (`tournament.knockout_size`, any power of 2: 2/4/8/16/32) was fully wired through the scoreboard, player dashboard, and bracket labels — but **one live surface still hardcoded top-8**.

The big-screen display (`/display`) and the admin live map render the Swiss standings with advancing teams highlighted green (emerald rows + `*`). The cutoff was a literal:

```tsx
// TournamentMapView.tsx
<StandingsColumn standings={standings} highlightTop={8} large={large} />
```

`TournamentMapViewProps` had no `playoffSize`, so all three callers (`DisplayPage`, admin `TournamentTab`, `SimulatorTab`) got `8` — even though two of them already *computed* the real `playoffSize`. For a top-4 or top-16 event, the live board greened the wrong set of teams.

## Fix

- Add a **required** `playoffSize` prop to `TournamentMapView`; `StandingsColumn` now uses `highlightTop={playoffSize}`.
- Thread the already-available value from all three callers.

Made the prop required (rather than defaulting to 8) so the compiler enforces every call site wires it — a clean `tsc` is proof all three are covered, and the bug can't silently reappear.

## Scope / not touched

- **Already dynamic, unchanged:** scoreboard subtext + green cutoff line, dashboard Gruppspel/Slutspel labels, knockout round labels (`knockoutLabels()`), the size dropdown.
- **Deliberately left:** the admin simulator stats panel's `(seed 1–8)` label + `.slice(0, 8)` — an offline analysis tool, never shown at the live event.

## Verification

- `npm run type-check` — clean (proves all callers wired)
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)